### PR TITLE
Potential fix for code scanning alert no. 2: Missing JWT signature check

### DIFF
--- a/cmd/argocd/commands/login.go
+++ b/cmd/argocd/commands/login.go
@@ -140,11 +140,17 @@ argocd login cd.argoproj.io --core`,
 					errors.CheckError(err)
 					tokenString, refreshToken = oauth2Login(ctx, ssoPort, acdSet.GetOIDCConfig(), oauth2conf, provider, ssoLaunchBrowser)
 				}
-				parser := jwt.NewParser(jwt.WithoutClaimsValidation())
 				claims := jwt.MapClaims{}
-				_, _, err := parser.ParseUnverified(tokenString, &claims)
+				DecodedToken, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+					// Replace with the actual key or validation logic
+					return []byte("your-signing-key"), nil
+				})
 				errors.CheckError(err)
-				fmt.Printf("'%s' logged in successfully\n", userDisplayName(claims))
+				if DecodedToken.Valid {
+					fmt.Printf("'%s' logged in successfully\n", userDisplayName(claims))
+				} else {
+					errors.CheckError(fmt.Errorf("invalid token"))
+				}
 			}
 
 			// login successful. Persist the config


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/argo-cd/security/code-scanning/2](https://github.com/codeallthethingsbreak/argo-cd/security/code-scanning/2)

To fix the issue, the JWT should be parsed and its signature verified using the `jwt.ParseWithClaims` method. This method requires a key or function to validate the token's signature. The fix involves replacing the `ParseUnverified` call with `ParseWithClaims` and providing the necessary key or validation function.

**Steps to implement the fix:**
1. Replace the `ParseUnverified` call on line 145 with `ParseWithClaims`.
2. Provide a key or validation function to verify the JWT's signature. This key should be securely obtained and match the one used to sign the JWT.
3. Ensure that the parsed token is checked for validity (`DecodedToken.Valid`) and handle errors appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
